### PR TITLE
Avoid endless loops

### DIFF
--- a/pages/nft-minters.tsx
+++ b/pages/nft-minters.tsx
@@ -72,6 +72,7 @@ export default function GetHolders() {
                 owners.push(owner);
               }
             }
+            return;
           } catch (e) {
             console.error(e?.message || e);
             errors.push({ address: addy, error: e?.message || e });
@@ -98,6 +99,7 @@ export default function GetHolders() {
           next: () => {
             const filename = `Minters-${Date.now()}.json`;
             download(filename, jsonFormat({ owners: [...owners], errors }));
+            setLoading(false);
             setModalState({
               message: `Succesfully downloaded ${filename}`,
               open: true,


### PR DESCRIPTION
An infinite loop was occurring in NFT Minters, which has been corrected.